### PR TITLE
Update cleanup script path and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,15 @@ terraform destroy
 
 Run this inside the `envs/dev` directory with the same workspace selected.
 
+For a quicker teardown of high-cost components (ECS services, ALB and IoT Core)
+you can execute the helper script:
+
+```bash
+./scripts/cleanup.sh
+```
+
+The script automatically switches to `envs/dev` and issues targeted `terraform destroy` commands, leaving core infrastructure such as the VPC and ECR repositories intact.
+
 ## Additional Notes
 
 - The Terraform configuration requires version `>= 1.8.0` and the AWS provider `~> 5.40` as defined in `envs/dev/versions.tf`.

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Always run Terraform from the dev environment directory
+cd "$(dirname "$0")/../envs/dev"
+
 echo "🔻 Starting cleanup of high-cost AWS infrastructure (containers, ALB, IoT)..."
 
 # Step 1: Stop and remove ECS services


### PR DESCRIPTION
## Summary
- adjust cleanup script to always run from `envs/dev`
- document the helper script in README

## Testing
- `bash -n scripts/cleanup.sh`
- `shellcheck scripts/cleanup.sh` *(fails: command not found)*
- `terraform --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68617b57ea9883239490063adff4f4a6