### PR TITLE
Improve TLS documentation and demo scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,11 @@ Re-running `terraform apply` will recreate the services when needed.
 ## Additional Notes
 
 - The Terraform configuration requires version `>= 1.8.0` and the AWS provider `~> 5.40` as defined in `envs/dev/versions.tf`.
-- GitHub Actions workflows under `ci/` will format Terraform code and perform planning on pull requests.ds
+- GitHub Actions workflows under `ci/` will format Terraform code and perform planning on pull requests.
+- The container applications connect to MQTT on port `8883` by default. Set
+  the environment variables `CA_CERT`, `CLIENT_CERT`, and `PRIVATE_KEY` with the
+  paths to your broker's certificate authority, client certificate and key to
+  enable TLS.
 - The container applications are minimal examples. Customize `openleadr/vtn_server.py` and `volttron/ven_agent.py` for your use case.
 
 ## OpenADR VTN
@@ -132,6 +136,10 @@ array of currently registered VEN IDs.
 Two helper scripts allow quick testing of the MQTT topics used by the VTN and
 VEN examples. Set `IOT_ENDPOINT` to the hostname of your MQTT broker (defaults
 to `localhost`).
+
+To use TLS when publishing or subscribing, pass `--port 8883` and set the
+environment variables `CA_CERT`, `CLIENT_CERT` and `PRIVATE_KEY` to point to
+your certificate files.
 
 1. Start monitoring responses for a VEN:
 

--- a/scripts/monitor_ven.py
+++ b/scripts/monitor_ven.py
@@ -18,10 +18,15 @@ def main() -> None:
     parser.add_argument(
         "--port", type=int, default=1883, help="MQTT broker port"
     )
+    ca_cert = os.getenv("CA_CERT")
+    client_cert = os.getenv("CLIENT_CERT")
+    private_key = os.getenv("PRIVATE_KEY")
     args = parser.parse_args()
 
     topic = f"grid/response/{args.ven_id}"
     client = mqtt.Client()
+    if ca_cert and client_cert and private_key:
+        client.tls_set(ca_certs=ca_cert, certfile=client_cert, keyfile=private_key)
 
     def on_message(client, userdata, msg):
         print(f"{msg.topic}: {msg.payload.decode()}")

--- a/scripts/send_event.py
+++ b/scripts/send_event.py
@@ -21,6 +21,9 @@ def main() -> None:
     parser.add_argument(
         "--port", type=int, default=1883, help="MQTT broker port"
     )
+    ca_cert = os.getenv("CA_CERT")
+    client_cert = os.getenv("CLIENT_CERT")
+    private_key = os.getenv("PRIVATE_KEY")
     args = parser.parse_args()
 
     event = {
@@ -34,6 +37,8 @@ def main() -> None:
     }
 
     client = mqtt.Client()
+    if ca_cert and client_cert and private_key:
+        client.tls_set(ca_certs=ca_cert, certfile=client_cert, keyfile=private_key)
     client.connect(args.host, args.port, 60)
     topic = f"grid/event/{args.ven_id}"
     payload = json.dumps(event)


### PR DESCRIPTION
## Summary
- document TLS environment variables in README
- mention send_event.py and monitor_ven.py demo scripts and how to use TLS
- add TLS support to the demo scripts
- fix stray text in README

## Testing
- `terraform fmt -recursive -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a1808dd4832382bda86878fce53b