### PR TITLE
Add Terraform format helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains Terraform modules and Dockerized applications to deploy
 - `modules/` – Reusable Terraform modules (VPC, ECS cluster, ECR repositories, security groups, IAM roles, IoT Core and more).
 - `openleadr/` – Source code and Dockerfile for the [OpenLEADR](https://github.com/OpenLEADR/openleadr) VTN server.
 - `volttron/` – Source code and Dockerfile for a simple Volttron VEN agent.
-- `scripts/` – Helper scripts to install dependencies, authenticate to AWS, create Terraform backend resources and push Docker images.
+- `scripts/` – Helper scripts to install dependencies, authenticate to AWS, create Terraform backend resources, push Docker images, and verify Terraform formatting.
 - `ci/` – GitHub Actions workflows for formatting and planning Terraform changes.
 
 ## Prerequisites
@@ -135,6 +135,7 @@ Re-running `terraform apply` will recreate the services when needed.
 
 - The Terraform configuration requires version `>= 1.8.0` and the AWS provider `~> 5.40` as defined in `envs/dev/versions.tf`.
 - GitHub Actions workflows under `ci/` will format Terraform code and perform planning on pull requests.
+- Run `scripts/check_terraform.sh` before committing to ensure Terraform files are formatted and valid.
 - The container applications connect to MQTT on port `8883` by default. Set
   the environment variables `CA_CERT`, `CLIENT_CERT`, and `PRIVATE_KEY` with the
   paths to your broker's certificate authority, client certificate and key to

--- a/scripts/check_terraform.sh
+++ b/scripts/check_terraform.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run Terraform formatting check across the repository
+terraform fmt -recursive -check
+
+# Validate each environment under envs/
+for env_dir in envs/*; do
+  if [[ -d "$env_dir" ]]; then
+    terraform validate "$env_dir"
+  fi
+done
+
+echo "✅ Terraform formatting and validation passed."


### PR DESCRIPTION
## Summary
- create a helper script to check terraform formatting and validation
- document helper usage in the README

## Testing
- `terraform fmt -recursive -check` *(fails: terraform not installed)*
- `terraform validate envs/dev` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865ac69651c8323bdf964fd11e8d122