### PR TITLE
Add MQTT_PORT env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ Re-running `terraform apply` will recreate the services when needed.
 
 - The Terraform configuration requires version `>= 1.8.0` and the AWS provider `~> 5.40` as defined in `envs/dev/versions.tf`.
 - GitHub Actions workflows under `ci/` will format Terraform code and perform planning on pull requests.
-- The container applications connect to MQTT on port `8883` by default. Set
-  the environment variables `CA_CERT`, `CLIENT_CERT`, and `PRIVATE_KEY` with the
-  paths to your broker's certificate authority, client certificate and key to
-  enable TLS.
+- The container applications connect to MQTT on the port specified by
+  `MQTT_PORT` (defaults to `8883`). Set the environment variables `CA_CERT`,
+  `CLIENT_CERT`, and `PRIVATE_KEY` with the paths to your broker's certificate
+  authority, client certificate and key to enable TLS.
 - The container applications are minimal examples. Customize `openleadr/vtn_server.py` and `volttron/ven_agent.py` for your use case.
 
 ## OpenADR VTN

--- a/modules/ecs-service-openadr/main.tf
+++ b/modules/ecs-service-openadr/main.tf
@@ -9,6 +9,7 @@ variable "mqtt_topic_events" {}
 variable "mqtt_topic_responses" {}
 variable "mqtt_topic_metering" {}
 variable "iot_endpoint" {}
+variable "mqtt_port" { default = "8883" }
 variable "target_group_arn" {}
 variable "cpu" { default = "256" }
 variable "memory" { default = "512" }
@@ -46,7 +47,8 @@ resource "aws_ecs_task_definition" "this" {
         { name = "MQTT_TOPIC_EVENTS", value = var.mqtt_topic_events },
         { name = "MQTT_TOPIC_RESPONSES", value = var.mqtt_topic_responses },
         { name = "MQTT_TOPIC_METERING", value = var.mqtt_topic_metering },
-        { name = "IOT_ENDPOINT", value = var.iot_endpoint }
+        { name = "IOT_ENDPOINT", value = var.iot_endpoint },
+        { name = "MQTT_PORT", value = var.mqtt_port }
       ]
       secrets = concat(
         var.ca_cert_secret_arn != null ? [{ name = "CA_CERT", valueFrom = var.ca_cert_secret_arn }] : [],

--- a/modules/ecs-service-volttron/main.tf
+++ b/modules/ecs-service-volttron/main.tf
@@ -10,6 +10,7 @@ variable "mqtt_topic_responses" {}
 variable "mqtt_topic_metering" {}
 variable "mqtt_topic_status" {}
 variable "iot_endpoint" {}
+variable "mqtt_port" { default = "8883" }
 variable "cpu" { default = "256" }
 variable "memory" { default = "512" }
 variable "ca_cert_secret_arn" { default = null }
@@ -41,7 +42,8 @@ resource "aws_ecs_task_definition" "this" {
         { name = "MQTT_TOPIC_RESPONSES", value = var.mqtt_topic_responses },
         { name = "MQTT_TOPIC_METERING", value = var.mqtt_topic_metering },
         { name = "MQTT_TOPIC_STATUS", value = var.mqtt_topic_status },
-        { name = "IOT_ENDPOINT", value = var.iot_endpoint }
+        { name = "IOT_ENDPOINT", value = var.iot_endpoint },
+        { name = "MQTT_PORT", value = var.mqtt_port }
       ]
       secrets = concat(
         var.ca_cert_secret_arn != null ? [{ name = "CA_CERT", valueFrom = var.ca_cert_secret_arn }] : [],

--- a/openleadr/Dockerfile
+++ b/openleadr/Dockerfile
@@ -6,7 +6,8 @@ COPY . .
 ENV MQTT_TOPIC_METERING=volttron/metering \
     CA_CERT=/certs/ca.crt \
     CLIENT_CERT=/certs/client.crt \
-    PRIVATE_KEY=/certs/client.key
+    PRIVATE_KEY=/certs/client.key \
+    MQTT_PORT=8883
 EXPOSE 8080
 CMD ["python", "vtn_server.py"]
 

--- a/openleadr/vtn_server.py
+++ b/openleadr/vtn_server.py
@@ -17,6 +17,7 @@ MQTT_TOPIC_METERING = os.getenv("MQTT_TOPIC_METERING", "volttron/metering")
 MQTT_TOPIC_EVENTS = os.getenv("MQTT_TOPIC_EVENTS", "openadr/event")
 MQTT_TOPIC_RESPONSES = os.getenv("MQTT_TOPIC_RESPONSES", "openadr/response")
 IOT_ENDPOINT = os.getenv("IOT_ENDPOINT", "localhost")
+MQTT_PORT = int(os.getenv("MQTT_PORT", "8883"))
 CA_CERT = os.getenv("CA_CERT")
 CLIENT_CERT = os.getenv("CLIENT_CERT")
 PRIVATE_KEY = os.getenv("PRIVATE_KEY")
@@ -41,7 +42,7 @@ def on_metering_data(client, userdata, msg):
 def on_response(client, userdata, msg):
     print(f"📩 Response received on {msg.topic}: {msg.payload.decode()}")
 
-mqtt_client.connect(IOT_ENDPOINT, 8883, 60)
+mqtt_client.connect(IOT_ENDPOINT, MQTT_PORT, 60)
 mqtt_client.subscribe(MQTT_TOPIC_METERING)
 mqtt_client.subscribe(MQTT_TOPIC_RESPONSES)
 mqtt_client.on_message = on_metering_data

--- a/volttron/Dockerfile
+++ b/volttron/Dockerfile
@@ -6,7 +6,8 @@ COPY . .
 ENV MQTT_TOPIC_METERING=volttron/metering \
     CA_CERT=/certs/ca.crt \
     CLIENT_CERT=/certs/client.crt \
-    PRIVATE_KEY=/certs/client.key
+    PRIVATE_KEY=/certs/client.key \
+    MQTT_PORT=8883
 EXPOSE 8080
 CMD ["python", "ven_agent.py"]
 

--- a/volttron/ven_agent.py
+++ b/volttron/ven_agent.py
@@ -11,6 +11,7 @@ MQTT_TOPIC_EVENTS = os.getenv("MQTT_TOPIC_EVENTS", "openadr/event")
 MQTT_TOPIC_RESPONSES = os.getenv("MQTT_TOPIC_RESPONSES", "openadr/response")
 MQTT_TOPIC_METERING = os.getenv("MQTT_TOPIC_METERING", "volttron/metering")
 IOT_ENDPOINT = os.getenv("IOT_ENDPOINT", "localhost")
+MQTT_PORT = int(os.getenv("MQTT_PORT", "8883"))
 CA_CERT = os.getenv("CA_CERT")
 CLIENT_CERT = os.getenv("CLIENT_CERT")
 PRIVATE_KEY = os.getenv("PRIVATE_KEY")
@@ -19,7 +20,7 @@ PRIVATE_KEY = os.getenv("PRIVATE_KEY")
 client = mqtt.Client()
 if CA_CERT and CLIENT_CERT and PRIVATE_KEY:
     client.tls_set(ca_certs=CA_CERT, certfile=CLIENT_CERT, keyfile=PRIVATE_KEY)
-client.connect(IOT_ENDPOINT, 8883, 60)
+client.connect(IOT_ENDPOINT, MQTT_PORT, 60)
 client.loop_start()
 
 # Event handler for incoming OpenADR events


### PR DESCRIPTION
## Summary
- allow MQTT port configuration for VTN and VEN Python scripts
- default MQTT_PORT to 8883 in Docker images
- expose MQTT_PORT in ECS service modules
- document MQTT_PORT usage

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `terraform validate -chdir=envs/dev` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ac99b40c8323b9b8fb0116f8388d