### PR TITLE
Add configurable VEN listing port

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,15 @@ Re-running `terraform apply` will recreate the services when needed.
 
 The `openleadr/vtn_server.py` script provides a minimal VTN for testing. The
 server listens on port `8080` for OpenADR traffic. It now tracks the VENs that
-register with it and exposes a simple HTTP endpoint to list them.
+register with it and exposes a simple HTTP endpoint to list them. The
+listing server's port can be configured via the `VENS_PORT` environment
+variable (default `8081`).
 
 ### Listing active VENs
 
-Run the server and then access `http://localhost:8081/vens` to retrieve a JSON
-array of currently registered VEN IDs.
+Run the server and then access `http://localhost:8081/vens` (or the port you
+set in `VENS_PORT`) to retrieve a JSON array of currently registered VEN
+IDs.
 
 
 ## Demo

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -76,6 +76,7 @@ module "ecs_service_openadr" {
   mqtt_topic_responses = "oadr/response/ven1"
   mqtt_topic_metering  = "oadr/meter/ven1"
   iot_endpoint         = module.iot_core.endpoint
+  vens_port            = 8081
   target_group_arn     = module.openadr_alb.target_group_arn
   # 👇 Add this to delay until the listener exists
   depends_on = [module.openadr_alb]

--- a/modules/ecs-service-openadr/main.tf
+++ b/modules/ecs-service-openadr/main.tf
@@ -15,6 +15,7 @@ variable "memory" { default = "512" }
 variable "ca_cert_secret_arn" { default = null }
 variable "client_cert_secret_arn" { default = null }
 variable "private_key_secret_arn" { default = null }
+variable "vens_port" { default = 8081 }
 
 data "aws_region" "current" {}
 
@@ -46,7 +47,8 @@ resource "aws_ecs_task_definition" "this" {
         { name = "MQTT_TOPIC_EVENTS", value = var.mqtt_topic_events },
         { name = "MQTT_TOPIC_RESPONSES", value = var.mqtt_topic_responses },
         { name = "MQTT_TOPIC_METERING", value = var.mqtt_topic_metering },
-        { name = "IOT_ENDPOINT", value = var.iot_endpoint }
+        { name = "IOT_ENDPOINT", value = var.iot_endpoint },
+        { name = "VENS_PORT", value = tostring(var.vens_port) }
       ]
       secrets = concat(
         var.ca_cert_secret_arn != null ? [{ name = "CA_CERT", valueFrom = var.ca_cert_secret_arn }] : [],

--- a/openleadr/Dockerfile
+++ b/openleadr/Dockerfile
@@ -6,7 +6,8 @@ COPY . .
 ENV MQTT_TOPIC_METERING=volttron/metering \
     CA_CERT=/certs/ca.crt \
     CLIENT_CERT=/certs/client.crt \
-    PRIVATE_KEY=/certs/client.key
+    PRIVATE_KEY=/certs/client.key \
+    VENS_PORT=8081
 EXPOSE 8080
 CMD ["python", "vtn_server.py"]
 

--- a/openleadr/vtn_server.py
+++ b/openleadr/vtn_server.py
@@ -1,7 +1,8 @@
 """Simple VTN server example used for development.
 
 This file keeps track of all VENs that register with the VTN and exposes
-an additional HTTP endpoint on port 8081 that lists those active VENs.
+an additional HTTP endpoint on a configurable port (`VENS_PORT`, default
+8081) that lists those active VENs.
 """
 
 from openleadr import OpenADRServer
@@ -87,6 +88,9 @@ def handle_event_request(ven_id, request):
     return [event]
 
 # Extra HTTP server to list active VENs
+VENS_PORT = int(os.getenv("VENS_PORT", "8081"))
+
+
 class VensHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/vens":
@@ -105,8 +109,8 @@ class VensHandler(BaseHTTPRequestHandler):
             self.end_headers()
 
 def run_vens_server():
-    httpd = HTTPServer(("0.0.0.0", 8081), VensHandler)
-    print("🔎 VEN listing server started on port 8081")
+    httpd = HTTPServer(("0.0.0.0", VENS_PORT), VensHandler)
+    print(f"🔎 VEN listing server started on port {VENS_PORT}")
     httpd.serve_forever()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow vens listing server port to be configured using `VENS_PORT`
- set default in Dockerfile and wire through ECS task definition
- expose the variable in the development environment
- document new `VENS_PORT` setting

## Testing
- `terraform fmt -recursive -check` *(fails: terraform not installed)*
- `terraform validate envs/dev` *(fails: terraform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865aca5328c8323b46fca792e65eee9