### PR TITLE
Add ECR login to Volttron build script

### DIFF
--- a/volttron/build_and_push.sh
+++ b/volttron/build_and_push.sh
@@ -2,9 +2,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+PROFILE="AdministratorAccess-923675928909"
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 REGION="${AWS_REGION:-us-west-2}"
 REPO_URI="$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com/volttron-ven"
+
+echo "Logging into ECR for profile $PROFILE..."
+aws ecr get-login-password --region "$REGION" --profile "$PROFILE" | \
+  docker login --username AWS --password-stdin "$REPO_URI"
 
 echo "Building and pushing to $REPO_URI..."
 docker build -t volttron-ven .


### PR DESCRIPTION
## Summary
- log in to ECR in `volttron/build_and_push.sh` using the same AWS profile as the OpenADR script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866f738875083239441fe6fa16dff44