### PR TITLE
Add Python compile check to lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,6 @@ jobs:
       - run: terraform fmt -recursive -check
       - run: terraform validate
         working-directory: envs/dev
+      - name: Compile Python files
+        run: python -m py_compile $(git ls-files '*.py')
 


### PR DESCRIPTION
## Summary
- run `python -m py_compile` after Terraform validation

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: IndentationError)*

------
https://chatgpt.com/codex/tasks/task_e_6866f762f6ec8323a15fbe2b3a7566c8