### PR TITLE
Fix Dockerfile build for openadr_backend

### DIFF
--- a/openadr_backend/Dockerfile
+++ b/openadr_backend/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 
 COPY ./app /app/app
 COPY ./pyproject.toml /app/
-COPY ./poetry.lock /app/
 
 RUN pip install --upgrade pip \
  && pip install poetry \


### PR DESCRIPTION
## Summary
- remove reference to `poetry.lock` in `openadr_backend` Dockerfile

## Testing
- `docker build .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d6437a7a0832389137297220a076a