### PR TITLE
Add task role output

### DIFF
--- a/modules/iam-roles/ecs_task_roles/main.tf
+++ b/modules/iam-roles/ecs_task_roles/main.tf
@@ -72,3 +72,7 @@ output "iot_mqtt" {
   value = aws_iam_role.iot_mqtt.arn
 }
 
+output "task_role_arn" {
+  value = aws_iam_role.iot_mqtt.arn
+}
+


### PR DESCRIPTION
## Summary
- expose task_role_arn in ecs_task_roles module

## Testing
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5b22bb48323a2371cf3e6d6d430