### PR TITLE
Fix security group output usage

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -131,7 +131,7 @@ module "ecs_service_backend" {
   task_role_arn      = module.ecs_task_roles.task_role_arn
 
   subnet_ids         = module.vpc.private_subnet_ids
-  security_group_id  = module.ecs_security_group.this_id
+  security_group_id  = module.ecs_security_group.id
   target_group_arn   = module.backend_alb.target_group_arn
   aws_region         = var.aws_region
 


### PR DESCRIPTION
## Summary
- fix reference to security group output

## Testing
- `terraform validate` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5b87f248323968dbda3195f9f3b