### PR TITLE
Expose postgres connection details

### DIFF
--- a/modules/rds-postgresql/output.tf
+++ b/modules/rds-postgresql/output.tf
@@ -5,3 +5,19 @@ output "cluster_endpoint" {
 output "reader_endpoint" {
   value = aws_rds_cluster.aurora_postgres.reader_endpoint
 }
+
+output "db_host" {
+  value     = aws_rds_cluster.aurora_postgres.endpoint
+}
+
+output "db_user" {
+  value = var.username
+}
+
+output "db_password" {
+  value     = var.password
+  sensitive = true
+}
+
+output "db_name" {
+  value = var.db_name}


### PR DESCRIPTION
## Summary
- expose db host, user, password, and name from the rds-postgresql module

## Testing
- `scripts/check_terraform.sh` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5c43ed483239e9e2d140076f97d