### PR TITLE
Add aws_region variable for dev environment

### DIFF
--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -1,0 +1,4 @@
+variable "aws_region" {
+  type    = string
+  default = "us-west-2"
+}

--- a/envs/dev/versions.tf
+++ b/envs/dev/versions.tf
@@ -9,6 +9,6 @@ terraform {
 }
 
 provider "aws" {
-  region = "us-west-2"
+  region = var.aws_region
 }
 


### PR DESCRIPTION
## Summary
- add `aws_region` variable for the dev environment
- use that variable in the AWS provider configuration

## Testing
- `./scripts/check_terraform.sh` *(fails: `terraform` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea5e6bd8c832387d607c999c67ac1