### PR TITLE
fix: correct backend service ARN output

### DIFF
--- a/modules/ecs-service-backend/outputs.tf
+++ b/modules/ecs-service-backend/outputs.tf
@@ -2,7 +2,7 @@ output "service_name" {
   value = aws_ecs_service.this.name
 }
 output "service_arn" {
-  value = aws_ecs_service.this.arn
+  value = aws_ecs_service.this.id
 }
 
 output "db_host" {


### PR DESCRIPTION
## Summary
- output the backend ECS service's ARN via `id` instead of the removed `arn` attribute

## Testing
- `terraform fmt modules/ecs-service-backend/outputs.tf` *(fails: command not found)*
- `terraform init -input=false` in `envs/dev` *(fails: command not found)*
- `terraform plan` in `envs/dev` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ee0ef10348323bfde90f5894f051e