### PR TITLE
Add settings and DB health check

### DIFF
--- a/openadr_backend/app/core/config.py
+++ b/openadr_backend/app/core/config.py
@@ -1,0 +1,16 @@
+from pydantic import BaseSettings
+
+class Settings(BaseSettings):
+    db_host: str
+    db_user: str
+    db_password: str
+    db_name: str
+
+    @property
+    def sqlalchemy_database_uri(self) -> str:
+        return (
+            f"postgresql+asyncpg://{self.db_user}:{self.db_password}"
+            f"@{self.db_host}:5432/{self.db_name}"
+        )
+
+settings = Settings()

--- a/openadr_backend/app/db/database.py
+++ b/openadr_backend/app/db/database.py
@@ -1,8 +1,9 @@
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
-import os
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://openadr_admin:Grid2025!@opendar-aurora.cluster-cfe6sou489x3.us-west-2.rds.amazonaws.com:5432/openadr")
+from app.core.config import settings
+
+DATABASE_URL = settings.sqlalchemy_database_uri
 
 
 engine = create_async_engine(DATABASE_URL, echo=True)

--- a/openadr_backend/app/main.py
+++ b/openadr_backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.routes import ven, event, health
+from app.routers import ven, event, health
 from app.db import database
 
 app = FastAPI(

--- a/openadr_backend/app/routers/health.py
+++ b/openadr_backend/app/routers/health.py
@@ -1,7 +1,20 @@
 from fastapi import APIRouter
+from sqlalchemy import text
+
+from app.db.database import engine
 
 router = APIRouter()
 
 @router.get("/health")
 async def health_check():
     return {"status": "ok"}
+
+
+@router.get("/db-check")
+async def db_check():
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("SELECT 1"))
+        return {"status": "ok"}
+    except Exception as e:
+        return {"status": "error", "details": str(e)}


### PR DESCRIPTION
## Summary
- create `Settings` using BaseSettings to build database URI
- use new Settings in the DB module
- expose `/db-check` endpoint for connectivity testing
- fix router import path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ef64642708323b196ea548573296a