### PR TITLE
Use consistent name for backend service

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -130,7 +130,7 @@ module "backend_alb" {
 
 module "ecs_service_backend" {
   source             = "../../modules/ecs-service-backend"
-  service_name       = "fastapi-backend"
+  service_name       = "openadr-backend"
   cluster_id         = module.ecs_cluster.id
   image              = "your-image-url"
   container_port     = 8000


### PR DESCRIPTION
## Summary
- rename backend ECS service from `fastapi-backend` to `openadr-backend`
- update Terraform import logic accordingly

## Testing
- `bash scripts/check_terraform.sh` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f066a54d88323b42b15d5c5cb6208