### PR TITLE
Automate Docker image pushes in dev_up

### DIFF
--- a/dev_up.sh
+++ b/dev_up.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 echo "🚀 Bringing up the full development environment..."
 
-cd "$(dirname "$0")/envs/dev"
+cd "$REPO_DIR/envs/dev"
 
 # Optional: Re-import resources if needed (only run this if your state was wiped)
 ./terraform_import.sh
 
 # Initialize and apply the infra
 ./terraform_init.sh
+
+# Build and push the Docker images for all services
+cd "$REPO_DIR/openleadr"
+./build_and_push.sh
+
+cd "$REPO_DIR/openadr_backend"
+./build_and_push.sh
+
+cd "$REPO_DIR/volttron"
+./build_and_push.sh
 
 echo "✅ Environment is up. All services should be running."
 


### PR DESCRIPTION
## Summary
- update `dev_up.sh` to automatically build and push Docker images for the openleadr, openadr-backend and volttron services

## Testing
- `./scripts/check_terraform.sh` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f4039439883239c2f6be360d32419