### PR TITLE
Implement event CRUD and startup migrations

### DIFF
--- a/openadr_backend/Dockerfile
+++ b/openadr_backend/Dockerfile
@@ -4,10 +4,12 @@ WORKDIR /app
 
 COPY ./app /app/app
 COPY ./pyproject.toml /app/
+COPY ./entrypoint.sh /entrypoint.sh
 
 RUN pip install --upgrade pip \
  && pip install poetry \
  && poetry config virtualenvs.create false \
- && poetry install --only main --no-root 
+ && poetry install --only main --no-root
 
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/openadr_backend/app/main.py
+++ b/openadr_backend/app/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import logging
 import sys
 
-from app.routers import health
+from app.routers import health, event, ven
 from app import routes
 
 app = FastAPI(
@@ -22,6 +22,8 @@ app.add_middleware(
 
 # Include routers
 app.include_router(health.router, prefix="/health", tags=["Health"])
+app.include_router(ven.router, prefix="/vens", tags=["VENs"])
+app.include_router(event.router, prefix="/events", tags=["Events"])
 app.include_router(routes.router)
 
 # Startup/shutdown hooks

--- a/openadr_backend/app/routers/event.py
+++ b/openadr_backend/app/routers/event.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from sqlalchemy import select
 from app.schemas.event import EventCreate, EventRead
 from app.models.event import Event
@@ -16,3 +16,18 @@ async def create_event(event: EventCreate):
 async def list_events():
     query = select(Event)
     return await database.fetch_all(query)
+
+
+@router.get("/ven/{ven_id}", response_model=list[EventRead])
+async def list_events_by_ven(ven_id: str):
+    query = select(Event).where(Event.ven_id == ven_id)
+    return await database.fetch_all(query)
+
+
+@router.get("/{event_id}", response_model=EventRead)
+async def get_event(event_id: str):
+    query = select(Event).where(Event.event_id == event_id)
+    row = await database.fetch_one(query)
+    if row:
+        return row
+    raise HTTPException(status_code=404, detail="Event not found")

--- a/openadr_backend/app/routers/health.py
+++ b/openadr_backend/app/routers/health.py
@@ -15,6 +15,17 @@ async def db_check():
     try:
         async with engine.begin() as conn:
             await conn.execute(text("SELECT 1"))
+            tables = ["vens", "events"]
+            for table in tables:
+                result = await conn.execute(
+                    text(
+                        "SELECT 1 FROM information_schema.tables "
+                        "WHERE table_schema='public' AND table_name=:t"
+                    ),
+                    {"t": table},
+                )
+                if result.scalar() is None:
+                    return {"status": "error", "details": f"table '{table}' missing"}
         return {"status": "ok"}
     except Exception as e:
         return {"status": "error", "details": str(e)}

--- a/openadr_backend/entrypoint.sh
+++ b/openadr_backend/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+alembic upgrade head
+exec "$@"


### PR DESCRIPTION
## Summary
- add entrypoint to run Alembic migrations automatically
- expose event and ven routers in FastAPI
- provide additional event routes to list by VEN and fetch by ID
- enhance DB health check to validate table presence

## Testing
- `python -m compileall openadr_backend/app`

------
https://chatgpt.com/codex/tasks/task_e_686f3f785e0883238d37a33c51abebe0