### PR TITLE
Fix backend ECS log group

### DIFF
--- a/modules/ecs-service-backend/main.tf
+++ b/modules/ecs-service-backend/main.tf
@@ -1,4 +1,8 @@
 #modules/ecs-service-backend/main.tf
+resource "aws_cloudwatch_log_group" "this" {
+  name = "/ecs/${var.service_name}"
+}
+
 resource "aws_ecs_task_definition" "this" {
   family                   = var.service_name
   network_mode             = "awsvpc"
@@ -10,8 +14,8 @@ resource "aws_ecs_task_definition" "this" {
 
   container_definitions = jsonencode([
     {
-      name      = var.service_name
-      image     = var.image
+      name  = var.service_name
+      image = var.image
       portMappings = [
         {
           containerPort = var.container_port
@@ -41,7 +45,7 @@ resource "aws_ecs_task_definition" "this" {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.this.name
           awslogs-region        = var.aws_region
-          awslogs-stream-prefix = var.name
+          awslogs-stream-prefix = var.service_name
         }
       }
     }

--- a/modules/ecs-service-backend/outputs.tf
+++ b/modules/ecs-service-backend/outputs.tf
@@ -5,6 +5,10 @@ output "service_arn" {
   value = aws_ecs_service.this.id
 }
 
+output "log_group_name" {
+  value = aws_cloudwatch_log_group.this.name
+}
+
 output "db_host" {
   value = var.db_host
 }


### PR DESCRIPTION
## Summary
- add CloudWatch log group to the backend ECS service
- use the service_name variable in the log configuration
- expose the backend service log group name as an output

## Testing
- `./scripts/install_terraform.sh`
- `./scripts/check_terraform.sh` *(fails: Module not installed - missing AWS credentials)*

------
https://chatgpt.com/codex/tasks/task_e_6870ab692b308323b71ede89c41cc9a7