### PR TITLE
Fix Alembic configuration path

### DIFF
--- a/openadr_backend/entrypoint.sh
+++ b/openadr_backend/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 set -e
-alembic -c /app/alembic upgrade head
+alembic -c /app/alembic.ini upgrade head
 exec "$@"


### PR DESCRIPTION
## Summary
- fix entrypoint path to use `/app/alembic.ini`

## Testing
- `python -m py_compile openadr_backend/app/**/*.py openadr_backend/app/*/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6870b52feabc8323bd1ba03394503193