### PR TITLE
Fix alembic import path

### DIFF
--- a/openadr_backend/alembic/env.py
+++ b/openadr_backend/alembic/env.py
@@ -4,6 +4,12 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from alembic import context
 from sqlmodel import SQLModel
 
+import os
+import sys
+
+# Ensure the "app" package is importable when running Alembic directly
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from app.db.database import engine
 
 config = context.config


### PR DESCRIPTION
## Summary
- ensure `app` module is found when running `alembic`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870b9781f2c83238727d697e9eb021b