### PR TITLE
Fix RDS engine version

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -107,7 +107,7 @@ module "aurora_postgresql" {
   source               = "../../modules/rds-postgresql"
   name                 = "opendar-aurora"
   db_name              = "openadrdb"
-  engine_version       = "15.5"
+  engine_version       = "15.10"
   username             = "openadr_admin"
   password             = "Grid2025!"  # Use Secrets Manager in production
   vpc_id               = module.vpc.vpc_id


### PR DESCRIPTION
## Summary
- update aurora_postgresql module to use engine version 15.10

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687192ba3a088323b7196f4f7a9daa3c