### PR TITLE
Fix openadr backend config

### DIFF
--- a/openadr_backend/app/core/config.py
+++ b/openadr_backend/app/core/config.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings
+# BaseSettings moved to the pydantic-settings package in Pydantic v2
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     db_host: str

--- a/openadr_backend/pyproject.toml
+++ b/openadr_backend/pyproject.toml
@@ -14,6 +14,7 @@ asyncpg = "^0.29.0"
 alembic = "^1.13.1"
 python-dotenv = "^1.0.0"
 pydantic = "^2.6.0"
+pydantic-settings = "^2.2.1"
 sqlmodel = "^0.0.14"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
## Summary
- import `BaseSettings` from `pydantic-settings`
- add `pydantic-settings` dependency to the Poetry config

## Testing
- `scripts/check_terraform.sh` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_687194810fa883238ae62f714154884a