### PR TITLE
Use SQLAlchemy session for router queries

### DIFF
--- a/openadr_backend/app/routers/event.py
+++ b/openadr_backend/app/routers/event.py
@@ -1,33 +1,46 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.schemas.event import EventCreate, EventRead
 from app.models.event import Event
-from app.db.database import database
+from app.db.database import get_session
 
 router = APIRouter()
 
 @router.post("/", response_model=EventRead)
-async def create_event(event: EventCreate):
-    query = Event.__table__.insert().values(**event.dict())
-    await database.execute(query)
-    return event
+async def create_event(
+    event: EventCreate,
+    session: AsyncSession = Depends(get_session),
+):
+    db_event = Event(**event.dict())
+    session.add(db_event)
+    await session.commit()
+    await session.refresh(db_event)
+    return db_event
 
 @router.get("/", response_model=list[EventRead])
-async def list_events():
-    query = select(Event)
-    return await database.fetch_all(query)
+async def list_events(session: AsyncSession = Depends(get_session)):
+    result = await session.execute(select(Event))
+    return result.scalars().all()
 
 
 @router.get("/ven/{ven_id}", response_model=list[EventRead])
-async def list_events_by_ven(ven_id: str):
-    query = select(Event).where(Event.ven_id == ven_id)
-    return await database.fetch_all(query)
+async def list_events_by_ven(
+    ven_id: str,
+    session: AsyncSession = Depends(get_session),
+):
+    result = await session.execute(select(Event).where(Event.ven_id == ven_id))
+    return result.scalars().all()
 
 
 @router.get("/{event_id}", response_model=EventRead)
-async def get_event(event_id: str):
-    query = select(Event).where(Event.event_id == event_id)
-    row = await database.fetch_one(query)
+async def get_event(
+    event_id: str,
+    session: AsyncSession = Depends(get_session),
+):
+    result = await session.execute(select(Event).where(Event.event_id == event_id))
+    row = result.scalars().first()
     if row:
         return row
     raise HTTPException(status_code=404, detail="Event not found")


### PR DESCRIPTION
## Summary
- refactor VEN router to use AsyncSession dependency
- refactor Event router to use AsyncSession dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687275fc00c4832384fb4a8fa3a25709