### PR TITLE
Fix health endpoint path

### DIFF
--- a/openadr_backend/app/routers/health.py
+++ b/openadr_backend/app/routers/health.py
@@ -5,7 +5,7 @@ from app.db.database import engine
 
 router = APIRouter()
 
-@router.get("/health")
+@router.get("/")
 async def health_check():
     return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- expose root health endpoint at `/health`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c3f8e7e8832384c93483c0b8d7be