### PR TITLE
Fix DB env var docs

### DIFF
--- a/openadr_backend/README.md
+++ b/openadr_backend/README.md
@@ -13,7 +13,7 @@ This directory contains a FastAPI application providing the administration API f
 
 ### Required environment variables
 
-The service loads its database settings from environment variables with the `POSTGRES_` prefix. Define the following variables or place them in a `.env` file:
+The service loads its database settings from environment variables with the `DB_` prefix. Define the following variables or place them in a `.env` file:
 
 - `DB_HOST` – hostname of the PostgreSQL server
 - `DB_USER` – database user


### PR DESCRIPTION
## Summary
- fix OpenADR backend docs to mention `DB_` prefix instead of `POSTGRES_`

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c3f0e8cc8323932c7a6da03fcfce