### PR TITLE
Add API tests and CI run

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,3 +16,15 @@ jobs:
       - name: Compile Python files
         run: python -m py_compile $(git ls-files '*.py')
 
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install fastapi uvicorn sqlalchemy asyncpg alembic python-dotenv pydantic pydantic-settings sqlmodel pytest httpx
+      - name: Run tests
+        run: pytest openadr_backend/tests
+

--- a/openadr_backend/pyproject.toml
+++ b/openadr_backend/pyproject.toml
@@ -18,6 +18,12 @@ pydantic = "^2.6.0"
 pydantic-settings = "^2.2.1"
 sqlmodel = "^0.0.24"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.0"
+httpx = "^0.27.0"
+pytest-asyncio = "^0.23.6"
+aiosqlite = "^0.20.0"
+
 [tool.poetry.scripts]
 start = "uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"
 

--- a/openadr_backend/tests/test_api.py
+++ b/openadr_backend/tests/test_api.py
@@ -1,0 +1,98 @@
+import os
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("DB_HOST", "test")
+os.environ.setdefault("DB_USER", "test")
+os.environ.setdefault("DB_PASSWORD", "test")
+os.environ.setdefault("DB_NAME", "test")
+
+from fastapi import FastAPI
+from app.routers import health, ven, event
+from app.db.database import get_session
+from app.models import Base
+
+
+def create_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(health.router, prefix="/health", tags=["Health"])
+    app.include_router(ven.router, prefix="/vens", tags=["VENs"])
+    app.include_router(event.router, prefix="/events", tags=["Events"])
+    return app
+
+app = create_app()
+
+DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(scope="module")
+async def async_client():
+    engine = create_async_engine(DATABASE_URL, future=True)
+    async_session = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+    async def override_get_session():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_session] = override_get_session
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+@pytest.mark.asyncio
+async def test_health(async_client):
+    resp = await async_client.get("/health/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+@pytest.mark.asyncio
+async def test_ven_endpoints(async_client):
+    ven_payload = {"ven_id": "ven123", "registration_id": "reg123"}
+    resp = await async_client.post("/vens/", json=ven_payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["ven_id"] == ven_payload["ven_id"]
+
+    resp = await async_client.get("/vens/")
+    assert resp.status_code == 200
+    assert any(v["ven_id"] == ven_payload["ven_id"] for v in resp.json())
+
+@pytest.mark.asyncio
+async def test_event_endpoints(async_client):
+    event_payload = {
+        "event_id": "evt1",
+        "ven_id": "ven123",
+        "signal_name": "simple",
+        "signal_type": "level",
+        "signal_payload": "1",
+        "start_time": "2024-01-01T00:00:00Z",
+        "response_required": "always",
+        "raw": {"a": "b"},
+    }
+    resp = await async_client.post("/events/", json=event_payload)
+    assert resp.status_code == 200
+    event = resp.json()
+    assert event["event_id"] == event_payload["event_id"]
+
+    resp = await async_client.get("/events/")
+    assert resp.status_code == 200
+    assert any(e["event_id"] == event_payload["event_id"] for e in resp.json())
+
+    resp = await async_client.get(f"/events/{event_payload['event_id']}")
+    assert resp.status_code == 200
+
+    resp = await async_client.get(f"/events/ven/{event_payload['ven_id']}")
+    assert resp.status_code == 200
+    assert any(e["event_id"] == event_payload["event_id"] for e in resp.json())
+


### PR DESCRIPTION
## Summary
- test backend FastAPI API endpoints using pytest, httpx and SQLite
- install test dependencies via Poetry
- run API tests in CI

## Testing
- `pytest openadr_backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c41e41c4832391ae23c99a9e219f