### PR TITLE
Fix volttron service in compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,6 @@ services:
       PRIVATE_KEY: /certs/client.key
     volumes:
       - ./certs:/certs:ro
+    command: ["python", "ven_agent.py"]
+    ports:
+      - "8082:8080"


### PR DESCRIPTION
## Summary
- add command and port mapping for the volttron service
- ensure docker-compose.yml is valid YAML

## Testing
- `./scripts/check_terraform.sh` *(fails: terraform not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873c417bc2883238a98831553f1d2e6