### PR TITLE
Use Secrets Manager for DB password

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -79,7 +79,7 @@ module "ecs_service_openadr" {
   target_group_arn     = module.openadr_alb.target_group_arn
   environment_secrets = [
     {
-      name       = "CERT_BUNDLE_JSON"
+      name      = "CERT_BUNDLE_JSON"
       valueFrom = "arn:aws:secretsmanager:us-west-2:923675928909:secret:openleadr-iot-cert-bundle-oWaWux"
     }
   ]
@@ -103,18 +103,32 @@ module "ecs_service_volttron" {
   iot_endpoint         = module.iot_core.endpoint
 }
 
+resource "aws_secretsmanager_secret" "openadr_db_password" {
+  name = "openadr-db-password"
+}
+
+resource "aws_secretsmanager_secret_version" "openadr_db_password" {
+  secret_id     = aws_secretsmanager_secret.openadr_db_password.id
+  secret_string = var.db_password
+}
+
+data "aws_secretsmanager_secret_version" "openadr_db_password" {
+  secret_id  = aws_secretsmanager_secret.openadr_db_password.id
+  depends_on = [aws_secretsmanager_secret_version.openadr_db_password]
+}
+
 module "aurora_postgresql" {
-  source               = "../../modules/rds-postgresql"
-  name                 = "opendar-aurora"
-  db_name              = "openadrdb"
-  engine_version       = "15.10"
-  username             = "openadr_admin"
-  password             = "Grid2025!"  # Use Secrets Manager in production
-  vpc_id               = module.vpc.vpc_id
-  subnet_ids           = module.vpc.private_subnet_ids
-  security_group_ids   = [module.ecs_security_group.id]
-  backup_retention     = 7
-  db_instance_class    = "db.t4g.medium"
+  source             = "../../modules/rds-postgresql"
+  name               = "opendar-aurora"
+  db_name            = "openadrdb"
+  engine_version     = "15.10"
+  username           = "openadr_admin"
+  password           = data.aws_secretsmanager_secret_version.openadr_db_password.secret_string
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [module.ecs_security_group.id]
+  backup_retention   = 7
+  db_instance_class  = "db.t4g.medium"
 }
 
 # Application load balancer for the backend service
@@ -138,35 +152,35 @@ module "ecr_backend" {
 }
 
 module "ecs_service_backend" {
-  source          = "../../modules/ecs-service-backend"
+  source = "../../modules/ecs-service-backend"
 
   # -------- names ----------
-  service_name    = "openadr-backend"
-  cluster_id      = module.ecs_cluster.id
+  service_name = "openadr-backend"
+  cluster_id   = module.ecs_cluster.id
 
   # -------- image ----------
-  image           = "${module.ecr_backend.repository_url}:latest"
+  image = "${module.ecr_backend.repository_url}:latest"
 
   # place in public subnet *for now* so it can reach ECR
-  subnet_ids      = module.vpc.public_subnets
-  security_group_id  = module.ecs_security_group.id
-  target_group_arn   = module.backend_alb.target_group_arn
+  subnet_ids        = module.vpc.public_subnets
+  security_group_id = module.ecs_security_group.id
+  target_group_arn  = module.backend_alb.target_group_arn
 
   # resources
-  cpu             = 256
-  memory          = 512
-  container_port  = 8000
+  cpu            = 256
+  memory         = 512
+  container_port = 8000
 
   # roles
   execution_role_arn = module.ecs_task_roles.execution
-  task_role_arn      = module.ecs_task_roles.iot_mqtt 
+  task_role_arn      = module.ecs_task_roles.iot_mqtt
 
   # DB connection env-vars
-  db_host         = module.aurora_postgresql.db_host
-  db_user         = module.aurora_postgresql.db_user
-  db_password     = module.aurora_postgresql.db_password
-  db_name         = module.aurora_postgresql.db_name
+  db_host     = module.aurora_postgresql.db_host
+  db_user     = module.aurora_postgresql.db_user
+  db_password = module.aurora_postgresql.db_password
+  db_name     = module.aurora_postgresql.db_name
 
-  aws_region      = var.aws_region
+  aws_region = var.aws_region
 }
 

--- a/envs/dev/variables.tf
+++ b/envs/dev/variables.tf
@@ -2,3 +2,9 @@ variable "aws_region" {
   type    = string
   default = "us-west-2"
 }
+
+variable "db_password" {
+  description = "Password for the OpenADR database"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- manage OpenADR DB password via Secrets Manager
- load secret for Aurora module

## Testing
- `terraform fmt -check envs/dev/main.tf envs/dev/variables.tf`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `pytest openadr_backend/tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6875fb1688bc8323875db45921950f71