### PR TITLE
Handle VEN registration ID conflicts

### DIFF
--- a/openadr_backend/app/routers/health.py
+++ b/openadr_backend/app/routers/health.py
@@ -6,6 +6,7 @@ from app.db.database import engine
 router = APIRouter()
 
 @router.get("/")
+@router.get("/health")
 async def health_check():
     return {"status": "ok"}
 

--- a/openadr_backend/app/routers/ven.py
+++ b/openadr_backend/app/routers/ven.py
@@ -1,6 +1,7 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import IntegrityError
 
 from app.schemas.ven import VENCreate, VENRead
 from app.models.ven import VEN
@@ -15,7 +16,13 @@ async def register_ven(
 ):
     db_ven = VEN(**ven.dict())
     session.add(db_ven)
-    await session.commit()
+    try:
+        await session.commit()
+    except IntegrityError as e:
+        await session.rollback()
+        if "registration_id" in str(e.orig):
+            raise HTTPException(status_code=409, detail="registration_id already exists")
+        raise
     await session.refresh(db_ven)
     return db_ven
 

--- a/openadr_backend/tests/test_api.py
+++ b/openadr_backend/tests/test_api.py
@@ -68,6 +68,14 @@ async def test_ven_endpoints(async_client):
     assert resp.status_code == 200
     assert any(v["ven_id"] == ven_payload["ven_id"] for v in resp.json())
 
+
+@pytest.mark.asyncio
+async def test_ven_registration_id_conflict(async_client):
+    payload = {"ven_id": "ven456", "registration_id": "reg123"}
+    resp = await async_client.post("/vens/", json=payload)
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "registration_id already exists"
+
 @pytest.mark.asyncio
 async def test_event_endpoints(async_client):
     event_payload = {


### PR DESCRIPTION
## Summary
- make health check accessible via `/health` endpoint
- handle database integrity error for duplicate `registration_id`
- test the integrity error path

## Testing
- `PYTHONPATH=$PWD/openadr_backend pytest -q openadr_backend/tests/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_6875fb20c18c8323b2d92782a38ba361