### PR TITLE
Retry DB migrations and wait for RDS

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -171,5 +171,10 @@ module "ecs_service_backend" {
   db_name         = module.aurora_postgresql.db_name
 
   aws_region      = var.aws_region
+
+  depends_on = [
+    module.backend_alb,
+    module.aurora_postgresql
+  ]
 }
 

--- a/openadr_backend/README.md
+++ b/openadr_backend/README.md
@@ -44,4 +44,6 @@ docker run -p 8000:8000 \
   openadr-backend
 ```
 
-The container's entrypoint runs database migrations via Alembic before starting the server.
+The container's entrypoint runs database migrations via Alembic before starting
+the server. It now retries the upgrade a few times to handle cases where the
+database is still coming online.

--- a/openadr_backend/entrypoint.sh
+++ b/openadr_backend/entrypoint.sh
@@ -1,4 +1,17 @@
 #!/bin/sh
 set -e
-alembic -c /app/alembic.ini upgrade head
+
+# Retry migrations a few times in case the database is still starting up
+MAX_TRIES=5
+TRY=1
+until alembic -c /app/alembic.ini upgrade head; do
+    if [ "$TRY" -ge "$MAX_TRIES" ]; then
+        echo "Failed to run migrations after $TRY attempts" >&2
+        exit 1
+    fi
+    echo "Alembic failed (attempt $TRY/$MAX_TRIES), retrying in 5s" >&2
+    TRY=$((TRY + 1))
+    sleep 5
+done
+
 exec "$@"


### PR DESCRIPTION
## Summary
- retry Alembic migrations in backend entrypoint
- document migration retries
- ensure backend ECS service waits on ALB and RDS

## Testing
- `terraform fmt -recursive`
- `terraform -chdir=envs/dev init -backend=false` *(fails: could not connect to registry.terraform.io)*

------
https://chatgpt.com/codex/tasks/task_e_6879de94724883239dba51b56790170d