### PR TITLE
Fix tests by adjusting Python path

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,6 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install fastapi uvicorn sqlalchemy asyncpg alembic python-dotenv pydantic pydantic-settings sqlmodel pytest httpx
+        run: pip install fastapi uvicorn sqlalchemy asyncpg alembic python-dotenv pydantic pydantic-settings sqlmodel pytest httpx pytest_asyncio
       - name: Run tests
         run: pytest openadr_backend/tests

--- a/openadr_backend/app/routers/__init__.py
+++ b/openadr_backend/app/routers/__init__.py
@@ -1,0 +1,1 @@
+# package marker

--- a/openadr_backend/tests/test_api.py
+++ b/openadr_backend/tests/test_api.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pytest
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -7,7 +8,12 @@ from sqlalchemy.orm import sessionmaker
 os.environ.setdefault("DB_HOST", "test")
 os.environ.setdefault("DB_USER", "test")
 os.environ.setdefault("DB_PASSWORD", "test")
+
 os.environ.setdefault("DB_NAME", "test")
+
+# Allow importing the `app` package when tests are executed without
+# installing the project by adding the parent directory to ``sys.path``.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from fastapi import FastAPI
 from app.routers import health, ven, event


### PR DESCRIPTION
## Summary
- ensure tests can import the `app` package

## Testing
- `scripts/check_terraform.sh` *(fails: module not installed)*
- `pytest openadr_backend/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_687aafa2e9888323a8008bc46727ab89