### PR TITLE
Add backend image build to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,8 @@ jobs:
         run: ./openleadr/build_and_push.sh
       - name: Build and push volttron image
         run: ./volttron/build_and_push.sh
+      - name: Build and push backend image
+        run: ./openadr_backend/build_and_push.sh
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ env.TF_VERSION }}


### PR DESCRIPTION
## Summary
- update deploy workflow so backend container image also publishes

## Testing
- `scripts/check_terraform.sh` *(fails: Module not installed)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687b49d3a8188323ab2aaf1a20d8d2d8