### PR TITLE
Fix test port usage

### DIFF
--- a/openleadr/tests/test_vtn_server.py
+++ b/openleadr/tests/test_vtn_server.py
@@ -14,7 +14,10 @@ def load_module(mock_client):
             "ca.crt": "CA",
             "client.crt": "CLIENT",
             "private.key": "KEY"
-        })
+        }),
+        # Use an ephemeral port for the VEN listing server so multiple test
+        # runs don't conflict over the same port.
+        "VENS_PORT": "0",
     }
     with mock.patch.dict(os.environ, env, clear=False), \
             mock.patch("paho.mqtt.client.Client", return_value=mock_client):


### PR DESCRIPTION
## Summary
- avoid address conflicts in `load_module` by using ephemeral VENS_PORT

## Testing
- `scripts/check_terraform.sh` *(fails: terraform not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b4a330bb483238a54f195be55d406