### PR TITLE
Fix backend ALB connectivity

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -42,10 +42,11 @@ module "ecs_cluster" {
 }
 
 module "ecs_security_group" {
-  source     = "../../modules/security-group"
-  name       = "ecs-tasks-sg"
-  vpc_id     = module.vpc.vpc_id
-  allow_http = true
+  source            = "../../modules/security-group"
+  name              = "ecs-tasks-sg"
+  vpc_id            = module.vpc.vpc_id
+  allow_http        = true
+  alb_backend_sg_id = module.backend_alb.security_group_id
 }
 
 module "ecs_task_roles" {

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -81,4 +81,5 @@ resource "aws_lb_listener" "http" {
 
 output "dns_name" { value = aws_lb.this.dns_name }
 output "target_group_arn" { value = aws_lb_target_group.this.arn }
+output "security_group_id" { value = aws_security_group.alb_sg.id }
 


### PR DESCRIPTION
## Summary
- export backend ALB security group id
- allow backend ALB to reach ECS tasks

## Testing
- `scripts/check_terraform.sh` *(fails: Module not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f293b1250832385dd42dc9d5eb4e9