### PR TITLE
Improve resiliency and configuration

### DIFF
--- a/openadr_backend/README.md
+++ b/openadr_backend/README.md
@@ -16,11 +16,13 @@ This directory contains a FastAPI application providing the administration API f
 The service loads its database settings from environment variables with the `DB_` prefix. Define the following variables or place them in a `.env` file:
 
 - `DB_HOST` – hostname of the PostgreSQL server
+- `DB_PORT` – port of the PostgreSQL server (default `5432`)
 - `DB_USER` – database user
 - `DB_PASSWORD` – user's password
 - `DB_NAME` – database name
+- `DB_TIMEOUT` – connection timeout in seconds (default `30`)
 
-The application connects on port `5432` by default.
+`DB_PORT` defaults to `5432` if unset.
 
 ## Running locally
 

--- a/openadr_backend/app/core/config.py
+++ b/openadr_backend/app/core/config.py
@@ -1,17 +1,21 @@
 # BaseSettings moved to the pydantic-settings package in Pydantic v2
 from pydantic_settings import BaseSettings
+from pydantic import Field
 
 class Settings(BaseSettings):
-    db_host: str
-    db_user: str
-    db_password: str
-    db_name: str
+    """Application configuration loaded from environment variables."""
 
-    # accept *either* DB_ or POSTGRES_ so nothing explodes while you migrate
+    db_host: str = Field(alias="DB_HOST")
+    db_port: int = Field(5432, alias="DB_PORT")
+    db_user: str = Field(alias="DB_USER")
+    db_password: str = Field(alias="DB_PASSWORD")
+    db_name: str = Field(alias="DB_NAME")
+    db_timeout: int = Field(30, alias="DB_TIMEOUT")
+
     model_config = {
-        "env_prefix": "",                         # read raw names
+        "env_prefix": "",
         "case_sensitive": False,
-        "extra": "ignore",                        # ignore stray vars
+        "extra": "ignore",
         "env_nested_delimiter": "__",
     }
 
@@ -19,7 +23,7 @@ class Settings(BaseSettings):
     def sqlalchemy_database_uri(self) -> str:
         return (
             f"postgresql+asyncpg://{self.db_user}:{self.db_password}"
-            f"@{self.db_host}:5432/{self.db_name}"
+            f"@{self.db_host}:{self.db_port}/{self.db_name}"
         )
 
 settings = Settings()

--- a/openadr_backend/app/db/database.py
+++ b/openadr_backend/app/db/database.py
@@ -6,7 +6,14 @@ from app.core.config import settings
 DATABASE_URL = settings.sqlalchemy_database_uri
 
 
-engine = create_async_engine(DATABASE_URL, echo=True)
+engine = create_async_engine(
+    DATABASE_URL,
+    echo=True,
+    pool_pre_ping=True,
+    pool_size=5,
+    max_overflow=10,
+    connect_args={"timeout": settings.db_timeout},
+)
 
 async_session = sessionmaker(
     bind=engine,

--- a/openadr_backend/entrypoint.sh
+++ b/openadr_backend/entrypoint.sh
@@ -2,14 +2,14 @@
 set -e
 
 # Retry migrations a few times in case the database is still starting up
-MAX_TRIES=5
+MAX_TRIES=${MAX_TRIES:-5}
 TRY=1
 until alembic -c /app/alembic.ini upgrade head; do
     if [ "$TRY" -ge "$MAX_TRIES" ]; then
         echo "Failed to run migrations after $TRY attempts" >&2
         exit 1
     fi
-    echo "Alembic failed (attempt $TRY/$MAX_TRIES), retrying in 5s" >&2
+    echo "Alembic failed to reach $DB_HOST:$DB_PORT (attempt $TRY/$MAX_TRIES), retrying in 5s" >&2
     TRY=$((TRY + 1))
     sleep 5
 done

--- a/openadr_backend/tests/test_api.py
+++ b/openadr_backend/tests/test_api.py
@@ -6,8 +6,10 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 os.environ.setdefault("DB_HOST", "test")
+os.environ.setdefault("DB_PORT", "5432")
 os.environ.setdefault("DB_USER", "test")
 os.environ.setdefault("DB_PASSWORD", "test")
+os.environ.setdefault("DB_TIMEOUT", "30")
 
 os.environ.setdefault("DB_NAME", "test")
 


### PR DESCRIPTION
## Summary
- document DB env vars and port/timeout in backend README
- load DB settings via explicit aliases
- tune async engine connection settings
- log host/port when Alembic retries
- allow insecure MQTT for VTN server with retries
- add health endpoint and retries for Volttron VEN

## Testing
- `./scripts/check_terraform.sh` *(fails: Module not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688154ae5a688323b4054104f79dbe36