### PR TITLE
Fix poetry install path in workflow

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -37,7 +37,8 @@ jobs:
         run: pip install poetry
       
       - name: Install dependencies for openadr_backend
-        run: poetry config virtualenvs.create false && poetry install --only main --no-root
+        working-directory: openadr_backend
+        run: poetry config virtualenvs.create false && poetry install --with dev --no-root
       
       - name: Run openadr_backend tests
         run: pytest openadr_backend/tests


### PR DESCRIPTION
## Summary
- run poetry install from openadr_backend
- install dev dependencies so pytest_asyncio is available

## Testing
- `./scripts/check_terraform.sh` *(fails: module not installed)*
- `pytest openadr_backend/tests`
- `pytest openleadr/tests`
- `pytest volttron/tests`


------
https://chatgpt.com/codex/tasks/task_e_6881587839ac8323b87a9a9b4bc6c1bf