### PR TITLE
Add flake8 lint step

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -16,3 +16,15 @@ jobs:
         run: ruff format --check .
       - name: Ruff lint
         run: ruff check .
+
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install flake8
+        run: pip install flake8
+      - name: Run flake8
+        run: flake8 .


### PR DESCRIPTION
## Summary
- add a Flake8 job to python lint workflow

## Testing
- `scripts/check_terraform.sh` *(fails: module not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881871c8b3883239edd92c965a6db4a