### PR TITLE
Fix conditional Volttron ALB rule

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -48,14 +48,15 @@ module "ecs_cluster" {
 }
 
 module "ecs_security_group" {
-  source             = "../../modules/security-group"
-  name               = "ecs-tasks-sg"
-  vpc_id             = module.vpc.vpc_id
-  allow_http         = false
-  alb_backend_sg_id  = module.backend_alb.security_group_id
-  alb_vtn_sg_id      = module.openadr_alb.security_group_id
-  alb_volttron_sg_id = module.volttron_alb.security_group_id
-  volttron_port      = 8000
+  source                   = "../../modules/security-group"
+  name                     = "ecs-tasks-sg"
+  vpc_id                   = module.vpc.vpc_id
+  allow_http               = false
+  alb_backend_sg_id        = module.backend_alb.security_group_id
+  alb_vtn_sg_id            = module.openadr_alb.security_group_id
+  alb_volttron_sg_id       = module.volttron_alb.security_group_id
+  enable_alb_volttron_rule = true
+  volttron_port            = 8000
 }
 
 module "ecs_task_roles" {

--- a/modules/security-group/main.tf
+++ b/modules/security-group/main.tf
@@ -21,6 +21,12 @@ variable "alb_volttron_sg_id" {
   default     = null
 }
 
+variable "enable_alb_volttron_rule" {
+  type        = bool
+  description = "Whether to create the Volttron ALB ingress rule"
+  default     = false
+}
+
 variable "volttron_port" {
   type        = number
   description = "Port used by the Volttron VEN health check"
@@ -82,7 +88,7 @@ resource "aws_security_group_rule" "from_alb_vtn" {
 }
 
 resource "aws_security_group_rule" "from_alb_volttron" {
-  count                    = var.alb_volttron_sg_id == null ? 0 : 1
+  count                    = var.enable_alb_volttron_rule ? 1 : 0
   type                     = "ingress"
   from_port                = var.volttron_port
   to_port                  = var.volttron_port


### PR DESCRIPTION
## Summary
- add a flag to enable the Volttron ALB rule
- use the flag to create the rule once the ALB SG exists
- enable the rule for the dev environment

## Testing
- `pytest -q`
- `scripts/check_terraform.sh` *(fails: Module not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688189da5c3c8323b7685a052ea68def