### PR TITLE
Remove duplicate mqtt loop start

### DIFF
--- a/openleadr/vtn_server.py
+++ b/openleadr/vtn_server.py
@@ -111,7 +111,6 @@ for attempt in range(1, 6):
         print(f"MQTT connect failed (try {attempt}/5): {e}", file=sys.stderr)
         time.sleep(min(2 ** attempt, 30))
 mqttc.loop_start()
-mqttc.loop_start()
 
 # ── Track registered VENs -----------------------------------------------
 active_vens: set[str] = set()


### PR DESCRIPTION
## Summary
- tidy up OpenADR VTN server startup sequence

## Testing
- `scripts/check_terraform.sh` *(fails: module not installed)*
- `pytest -q` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6886aeaa05f48323b8d236dcda46d481