### PR TITLE
Add Swagger docs to services

### DIFF
--- a/openadr_backend/app/main.py
+++ b/openadr_backend/app/main.py
@@ -7,7 +7,9 @@ from app.routers import health, event, ven
 
 app = FastAPI(
     title="OpenADR VTN Admin API",
-    version="0.1.0"
+    version="0.1.0",
+    docs_url="/docs",
+    openapi_url="/openapi.json",
 )
 
 # CORS (adjust origins as needed)

--- a/openadr_backend/tests/test_api.py
+++ b/openadr_backend/tests/test_api.py
@@ -59,7 +59,7 @@ async def async_client():
 
 @pytest.mark.asyncio
 async def test_health(async_client):
-    resp = await async_client.get("/health/")
+    resp = await async_client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
 

--- a/openleadr/tests/test_vtn_server.py
+++ b/openleadr/tests/test_vtn_server.py
@@ -47,3 +47,8 @@ def test_handle_event_request_publishes():
     assert data["ven_id"] == "ven1"
     assert result[0]["targets"]["ven_id"] == "ven1"
 
+
+def test_openapi_spec_has_health():
+    module = load_module(mock.Mock())
+    assert "/health" in module.OPENAPI_SPEC["paths"]
+


### PR DESCRIPTION
## Summary
- expose Swagger UI and OpenAPI spec from OpenADR backend, OpenLEADR VTN and Volttron VEN services
- adjust tests for new endpoints
- configure VEN health server port via `HEALTH_PORT`

## Testing
- `scripts/check_terraform.sh` *(fails: module not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b0d0ad9c8323a85cf560cc10bbb4