### PR TITLE
Fix ALB health script desiredCount null bug

### DIFF
--- a/scripts/ecs-alb-health.sh
+++ b/scripts/ecs-alb-health.sh
@@ -38,8 +38,8 @@ check_service() {
   fi
 
   local desired running tg_arn
-  desired=$(jq -r '.services[0].desiredCount' <<<"$svc_json")
-  running=$(jq -r '.services[0].runningCount' <<<"$svc_json")
+  desired=$(jq -r '.services[0].desiredCount // 0' <<<"$svc_json")
+  running=$(jq -r '.services[0].runningCount // 0' <<<"$svc_json")
   tg_arn=$(jq -r '.services[0].loadBalancers[0].targetGroupArn // empty' <<<"$svc_json")
 
   # default summary line


### PR DESCRIPTION
## Summary
- handle `null` desired/running counts in `ecs-alb-health.sh`

## Testing
- `scripts/check_terraform.sh` *(fails: Module not installed)*
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886b9d0c770832380f3374c51b1fe18