### PR TITLE
Fix health route definition

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -146,10 +146,10 @@ module "backend_alb" {
 }
 
 module "volttron_alb" {
-  source            = "../../modules/alb"
-  name              = "volttron-alb"
-  vpc_id            = module.vpc.vpc_id
-  public_subnets    = module.vpc.public_subnets
+  source         = "../../modules/alb"
+  name           = "volttron-alb"
+  vpc_id         = module.vpc.vpc_id
+  public_subnets = module.vpc.public_subnets
   # Expose the Volttron service publicly for easier debugging
   # by placing the ALB in the public subnets and making it
   # internet-facing. The default `internal` value is false

--- a/openleadr/vtn_server.py
+++ b/openleadr/vtn_server.py
@@ -167,23 +167,22 @@ vtn = OpenADRServer(vtn_id="myVtn", http_port=8080, ven_lookup=ven_lookup)
 
 # ── Simple /health endpoint (same port 8080) -----------------------------
 app = web.Application()
+routes = web.RouteTableDef()
 
+@routes.get("/openapi.json")
 async def _openapi(_: web.Request):
     return web.json_response(OPENAPI_SPEC)
 
+@routes.get("/docs")
 async def _docs(_: web.Request):
     return web.Response(text=SWAGGER_HTML, content_type="text/html")
 
+@routes.get("/health")
 async def _health(_: web.Request):
     return web.json_response({"ok": mqtt_connected})
 
-app.router.add_get("/health", _health)
-app.router.add_get("/openapi.json", _openapi)
-app.router.add_get("/docs", _docs)
-
-vtn.app.router.add_get("/health", _health)
-vtn.app.router.add_get("/openapi.json", _openapi)
-vtn.app.router.add_get("/docs", _docs)
+app.add_routes(routes)
+vtn.app.add_routes(routes)
 
 # ── VEN listing HTTP server (separate port) ------------------------------
 class VenHandler(BaseHTTPRequestHandler):


### PR DESCRIPTION
## Summary
- run Terraform formatter
- switch health endpoint registration to RouteTableDef

## Testing
- `pytest -q`
- `scripts/check_terraform.sh` *(fails: Module not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886bd8ee9848323896e5126b890a825