### PR TITLE
Add ECS health check to deploy workflow

### DIFF
--- a/.github/workflows/deploy-services.yml
+++ b/.github/workflows/deploy-services.yml
@@ -53,3 +53,21 @@ jobs:
               --force-new-deployment \
               --region $AWS_REGION
           done
+
+      - name: Verify ECS Services are Healthy
+        run: |
+          for svc in openadr-backend openleadr-vtn volttron-ven; do
+            echo "Checking service: $svc"
+            aws ecs wait services-stable \
+              --cluster $CLUSTER_NAME \
+              --services "$svc" \
+              --region $AWS_REGION
+            echo "$svc is stable ✅"
+          done
+
+      - name: Print ECR Image Summary
+        run: |
+          echo "### Images Deployed" >> $GITHUB_STEP_SUMMARY
+          for svc in openadr-backend openleadr-vtn volttron-ven; do
+            echo "- $svc deployed to ECS cluster: $CLUSTER_NAME" >> $GITHUB_STEP_SUMMARY
+          done


### PR DESCRIPTION
## Summary
- deploy workflow waits for services to stabilize
- write image summary to job summary for easier review

## Testing
- `scripts/check_terraform.sh` *(fails: module not installed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688a603e6088832392fb0aeb2d7ac3d0