### PR TITLE
Inject DB variables for OpenLEADR service

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -89,6 +89,11 @@ module "ecs_service_openadr" {
       valueFrom = "arn:aws:secretsmanager:us-west-2:923675928909:secret:openleadr-iot-cert-bundle-oWaWux"
     }
   ]
+  db_host                   = module.aurora_postgresql.db_host
+  db_user                   = module.aurora_postgresql.db_user
+  db_password               = module.aurora_postgresql.db_password
+  db_name                   = module.aurora_postgresql.db_name
+  run_migrations_on_startup = false
 
   # Ensure the ECS service waits for the ALB listener and target group to be
   # created before attempting to register. This avoids race conditions during

--- a/modules/ecs-service-openadr/main.tf
+++ b/modules/ecs-service-openadr/main.tf
@@ -47,9 +47,19 @@ resource "aws_ecs_task_definition" "this" {
         { name = "MQTT_TOPIC_RESPONSES", value = var.mqtt_topic_responses },
         { name = "MQTT_TOPIC_METERING", value = var.mqtt_topic_metering },
         { name = "IOT_ENDPOINT", value = var.iot_endpoint },
-        { name = "VENS_PORT", value = tostring(var.vens_port) }
+        { name = "VENS_PORT", value = tostring(var.vens_port) },
+        { name = "DB_HOST", value = var.db_host },
+        { name = "DB_USER", value = var.db_user },
+        { name = "DB_NAME", value = var.db_name },
+        { name = "RUN_MIGRATIONS_ON_STARTUP", value = tostring(var.run_migrations_on_startup) }
       ]
-      secrets = var.environment_secrets
+      secrets = concat(
+        var.environment_secrets,
+        [{
+          name      = "DB_PASSWORD"
+          valueFrom = var.db_password
+        }]
+      )
       logConfiguration = {
         logDriver = "awslogs"
         options = {

--- a/modules/ecs-service-openadr/variables.tf
+++ b/modules/ecs-service-openadr/variables.tf
@@ -3,3 +3,29 @@ variable "environment_secrets" {
   default = []
 }
 
+variable "db_host" {
+  type    = string
+  default = ""
+}
+
+variable "db_user" {
+  type    = string
+  default = ""
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+  default   = ""
+}
+
+variable "db_name" {
+  type    = string
+  default = ""
+}
+
+variable "run_migrations_on_startup" {
+  type    = bool
+  default = true
+}
+

--- a/openadr_backend/entrypoint.sh
+++ b/openadr_backend/entrypoint.sh
@@ -2,16 +2,18 @@
 set -e
 
 # Retry migrations a few times in case the database is still starting up
-MAX_TRIES=${MAX_TRIES:-5}
-TRY=1
-until alembic -c /app/alembic.ini upgrade head; do
-    if [ "$TRY" -ge "$MAX_TRIES" ]; then
-        echo "Failed to run migrations after $TRY attempts" >&2
-        exit 1
-    fi
-    echo "Alembic failed to reach $DB_HOST:$DB_PORT (attempt $TRY/$MAX_TRIES), retrying in 5s" >&2
-    TRY=$((TRY + 1))
-    sleep 5
-done
+if [ "${RUN_MIGRATIONS_ON_STARTUP:-true}" != "false" ]; then
+    MAX_TRIES=${MAX_TRIES:-5}
+    TRY=1
+    until alembic -c /app/alembic.ini upgrade head; do
+        if [ "$TRY" -ge "$MAX_TRIES" ]; then
+            echo "Failed to run migrations after $TRY attempts" >&2
+            exit 1
+        fi
+        echo "Alembic failed to reach $DB_HOST:$DB_PORT (attempt $TRY/$MAX_TRIES), retrying in 5s" >&2
+        TRY=$((TRY + 1))
+        sleep 5
+    done
+fi
 
 exec "$@"


### PR DESCRIPTION
## Summary
- add database settings to `ecs-service-openadr` module
- surface the Aurora DB settings in the dev environment
- gate backend migrations with `RUN_MIGRATIONS_ON_STARTUP`

## Testing
- `scripts/check_terraform.sh` *(fails: Module not installed)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a699dd2808323a968f26e1ef1bcaa