### PR TITLE
Expose frontend ALB DNS output

### DIFF
--- a/envs/dev/outputs.tf
+++ b/envs/dev/outputs.tf
@@ -36,3 +36,9 @@ output "backend_alb_dns_name" {
   value       = module.backend_alb.dns_name
 }
 
+# DNS name for the frontend ALB
+output "frontend_alb_dns_name" {
+  description = "Public DNS of the frontend ALB"
+  value       = module.frontend_alb.dns_name
+}
+


### PR DESCRIPTION
## Summary
- surface the frontend ALB DNS so it can be referenced by other components

## Testing
- `terraform fmt`
- `terraform init -backend=false` *(fails: could not connect to registry.terraform.io)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_688c4b02338883238b756987a3647299