### PR TITLE
Add lifecycle safeguards for Volttron IoT resources

### DIFF
--- a/envs/dev/terraform_import.sh
+++ b/envs/dev/terraform_import.sh
@@ -45,6 +45,19 @@ is_imported "module.ecs_task_roles.aws_iam_role.iot_mqtt"  || safe_import "modul
 echo "🔗 Importing IoT policy..."
 is_imported "module.iot_core.aws_iot_policy.allow_publish_subscribe" || safe_import "module.iot_core.aws_iot_policy.allow_publish_subscribe" "volttron_policy"
 
+### IoT Thing & Certificate
+echo "🔧 Importing IoT thing & certificate..."
+is_imported "module.iot_core.aws_iot_thing.volttron" || safe_import "module.iot_core.aws_iot_thing.volttron" "volttron_thing"
+
+cert_arn=$(aws iot list-certificates --region "$REGION" --query 'certificates[?status==`ACTIVE`][0].certificateArn' --output text 2>/dev/null || echo "")
+if [[ -n "$cert_arn" ]]; then
+  echo "🔐 Importing IoT certificate: $cert_arn"
+  is_imported "module.iot_core.aws_iot_certificate.volttron" || safe_import "module.iot_core.aws_iot_certificate.volttron" "$cert_arn"
+  is_imported "module.iot_core.aws_iot_thing_principal_attachment.volttron" || safe_import "module.iot_core.aws_iot_thing_principal_attachment.volttron" "volttron_thing|$cert_arn"
+else
+  echo "⚠️  Could not determine IoT certificate ARN; skipping certificate import."
+fi
+
 ### ALB and Target Group
 echo "🌐 Fetching ALB and target group ARNs..."
 alb_arn=$(aws elbv2 describe-load-balancers --names openadr-vtn-alb --region "$REGION" --query "LoadBalancers[0].LoadBalancerArn" --output text || echo "")

--- a/modules/iot-core/main.tf
+++ b/modules/iot-core/main.tf
@@ -20,12 +20,12 @@ resource "aws_iot_topic_rule" "forward_to_s3" {
 #  Access policy
 ############################################################
 resource "aws_iot_policy" "allow_publish_subscribe" {
-  name   = "${var.prefix}_policy"
+  name = "${var.prefix}_policy"
   policy = jsonencode({
-    Version   = "2012-10-17"
+    Version = "2012-10-17"
     Statement = [{
       Effect   = "Allow"
-      Action   = ["iot:Connect","iot:Publish","iot:Subscribe","iot:Receive"]
+      Action   = ["iot:Connect", "iot:Publish", "iot:Subscribe", "iot:Receive"]
       Resource = "*"
     }]
   })
@@ -34,12 +34,21 @@ resource "aws_iot_policy" "allow_publish_subscribe" {
 ############################################################
 #  Device identity
 ############################################################
-resource "aws_iot_certificate" "cert" {
+resource "aws_iot_certificate" "volttron" {
   active = true
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
-resource "aws_iot_thing" "device_sim" {
+resource "aws_iot_thing" "volttron" {
   name = "${var.prefix}_thing"
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes  = [attributes]
+  }
 }
 
 ############################################################
@@ -47,7 +56,7 @@ resource "aws_iot_thing" "device_sim" {
 ############################################################
 resource "aws_iot_policy_attachment" "cert_policy" {
   policy = aws_iot_policy.allow_publish_subscribe.name
-  target = aws_iot_certificate.cert.arn
+  target = aws_iot_certificate.volttron.arn
 
   # Prevent the destroy-before-detach race:
   lifecycle {
@@ -55,9 +64,9 @@ resource "aws_iot_policy_attachment" "cert_policy" {
   }
 }
 
-resource "aws_iot_thing_principal_attachment" "thing_cert" {
-  thing     = aws_iot_thing.device_sim.name
-  principal = aws_iot_certificate.cert.arn
+resource "aws_iot_thing_principal_attachment" "volttron" {
+  thing     = aws_iot_thing.volttron.name
+  principal = aws_iot_certificate.volttron.arn
 
   # Same ordering safeguard
   lifecycle {

--- a/modules/iot-core/output.tf
+++ b/modules/iot-core/output.tf
@@ -1,17 +1,17 @@
 output "thing_name" {
-  value = aws_iot_thing.device_sim.name
+  value = aws_iot_thing.volttron.name
 }
 
 output "certificate_pem" {
-  value = aws_iot_certificate.cert.certificate_pem
+  value = aws_iot_certificate.volttron.certificate_pem
 }
 
 output "private_key" {
-  value = aws_iot_certificate.cert.private_key
+  value = aws_iot_certificate.volttron.private_key
 }
 
 output "public_key" {
-  value = aws_iot_certificate.cert.public_key
+  value = aws_iot_certificate.volttron.public_key
 }
 
 output "policy_name" {


### PR DESCRIPTION
## Summary
- reintroduce Volttron IoT Thing and certificate with destroy protection
- expose updated Thing and certificate outputs
- add import script steps for Volttron IoT Thing, certificate, and attachment

## Testing
- `scripts/check_terraform.sh`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ce9ec60b083238f18503e9e27cdd3