### PR TITLE
chore: sort imports in ven agent test

### DIFF
--- a/volttron/tests/test_ven_agent.py
+++ b/volttron/tests/test_ven_agent.py
@@ -1,8 +1,8 @@
 import importlib.util
+import json
+import os
 from pathlib import Path
 from unittest import mock
-import os
-import json
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "ven_agent.py"
 


### PR DESCRIPTION
## Summary
- sort imports in volttron/tests/test_ven_agent.py to ensure importlib.util is included

## Testing
- `scripts/check_terraform.sh` *(fails: terraform: command not found)*
- `pytest volttron/tests`

------
https://chatgpt.com/codex/tasks/task_e_688ce9f9543483239dd0399de324bdec