### PR TITLE
Add VPC endpoints and security group rule for ECS tasks

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -53,6 +53,15 @@ module "ecs_security_group" {
   vpc_id = module.vpc.vpc_id
 }
 
+resource "aws_security_group_rule" "vpc_endpoints_ingress_from_tasks" {
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = module.vpc.vpc_endpoints_security_group_id
+  source_security_group_id = module.ecs_security_group.id
+}
+
 module "ecs_task_roles" {
   source      = "../../modules/iam-roles/ecs_task_roles"
   name_prefix = "grid-sim"

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -3,4 +3,5 @@ output "vpc_id" { value = aws_vpc.this.id }
 output "public_subnets" { value = aws_subnet.public[*].id }
 output "private_subnet_ids" { value = aws_subnet.private[*].id }
 output "cidr_block" { value = var.cidr_block }
+output "vpc_endpoints_security_group_id" { value = aws_security_group.vpc_endpoints.id }
 


### PR DESCRIPTION
## Summary
- add VPC security group for interface endpoints and create endpoints for Secrets Manager, ECR, CloudWatch Logs, and S3
- expose security group ID from VPC module
- allow ECS tasks to reach VPC endpoints via dedicated security group rule

## Testing
- `scripts/check_terraform.sh` *(fails: modules/ecr-repo/main.tf, modules/iot-rule-forwarder/main.tf, modules/security-group/main.tf would be reformatted)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68919e2796d483238aebb0f29719d507