### PR TITLE
Allow ECS execution role to read TLS secret

### DIFF
--- a/modules/iam-roles/ecs_task_roles/main.tf
+++ b/modules/iam-roles/ecs_task_roles/main.tf
@@ -85,6 +85,11 @@ resource "aws_iam_role_policy_attachment" "attach_tls_secret" {
   policy_arn = aws_iam_policy.allow_tls_secret_access.arn
 }
 
+resource "aws_iam_role_policy_attachment" "attach_execution_tls_secret" {
+  role       = aws_iam_role.execution.name
+  policy_arn = aws_iam_policy.allow_tls_secret_access.arn
+}
+
 output "execution" {
   value = aws_iam_role.execution.arn
 }


### PR DESCRIPTION
## Summary
- attach the TLS secret access policy to the ECS task execution role so containers can pull their Secrets Manager values during startup

## Testing
- scripts/check_terraform.sh *(fails: module not installed; requires `terraform init` which is disallowed in this environment)*
- `CA_CERT=/tmp/ca.pem CLIENT_CERT=/tmp/client.pem PRIVATE_KEY=/tmp/key.pem pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd946616f48323bdb946c09c496f5c