### PR TITLE
Restore mandatory VEN TLS and support PEM env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ Re-running `terraform apply` will recreate the services when needed.
 - The Terraform configuration requires version `>= 1.8.0` and the AWS provider `~> 5.40` as defined in `envs/dev/versions.tf`.
 - GitHub Actions workflows automatically lint, test, scan for vulnerabilities and generate Terraform plans on pull requests.
 - Run `scripts/check_terraform.sh` before committing to ensure Terraform files are formatted and valid.
-- The container applications connect to MQTT on port `8883` by default. Set
-  the environment variables `CA_CERT`, `CLIENT_CERT`, and `PRIVATE_KEY` with the
-  paths to your broker's certificate authority, client certificate and key to
-  enable TLS.
+- The container applications connect to MQTT on port `8883` by default. Set the
+  environment variables `CA_CERT`, `CLIENT_CERT`, and `PRIVATE_KEY` (or the
+  `_PEM`-suffixed variants) with the paths or PEM contents for your broker's
+  certificate authority, client certificate and key to enable TLS.
 - By default the applications target the AWS IoT Core endpoint
   `vpce-0d3cb8ea5764b8097-r1j8w787.data.iot.us-west-2.vpce.amazonaws.com`. Set
   the `IOT_ENDPOINT` environment variable if you need to override this.

--- a/volttron-ven/tests/test_ven_agent.py
+++ b/volttron-ven/tests/test_ven_agent.py
@@ -7,8 +7,17 @@ from unittest import mock
 MODULE_PATH = Path(__file__).resolve().parents[1] / "ven_agent.py"
 
 
+FAKE_CERT = """-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----"""
+FAKE_KEY = """-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----"""
+
+
 def load_module(mock_client):
-    env = {"HEALTH_PORT": "0"}
+    env = {
+        "HEALTH_PORT": "0",
+        "CA_CERT_PEM": FAKE_CERT,
+        "CLIENT_CERT_PEM": FAKE_CERT,
+        "PRIVATE_KEY_PEM": FAKE_KEY,
+    }
     with mock.patch.dict(os.environ, env, clear=False), \
             mock.patch("paho.mqtt.client.Client", return_value=mock_client):
         spec = importlib.util.spec_from_file_location("ven_agent", MODULE_PATH)

--- a/volttron-ven/ven_agent.py
+++ b/volttron-ven/ven_agent.py
@@ -69,17 +69,19 @@ def fetch_tls_creds_from_secrets(secret_name: str, region_name="us-west-2") -> d
         print(f"❌ Error fetching TLS secrets: {e}", file=sys.stderr)
         return None
 
-def _materialise_pem(var_name: str) -> str | None:
+def _materialise_pem(*var_names: str) -> str | None:
     """Return a file-path ready for paho.tls_set()."""
-    val = os.getenv(var_name)
-    if not val:
-        return None
-    if val.startswith("-----BEGIN"):
-        pem_path = pathlib.Path(tempfile.gettempdir()) / f"{var_name.lower()}.pem"
-        pem_path.write_text(val)
-        os.environ[var_name] = str(pem_path)
-        return str(pem_path)
-    return val
+    for var_name in var_names:
+        val = os.getenv(var_name)
+        if not val:
+            continue
+        if val.startswith("-----BEGIN"):
+            pem_path = pathlib.Path(tempfile.gettempdir()) / f"{var_name.lower()}.pem"
+            pem_path.write_text(val)
+            os.environ[var_name] = str(pem_path)
+            return str(pem_path)
+        return val
+    return None
 
 # ── env / config ───────────────────────────────────────────────────────
 MQTT_TOPIC_STATUS     = os.getenv("MQTT_TOPIC_STATUS", "volttron/dev")
@@ -91,6 +93,7 @@ IOT_ENDPOINT          = os.getenv("IOT_ENDPOINT", DEFAULT_IOT_ENDPOINT)
 HEALTH_PORT           = int(os.getenv("HEALTH_PORT", "8000"))
 TLS_SECRET_NAME       = os.getenv("TLS_SECRET_NAME")
 AWS_REGION            = os.getenv("AWS_REGION", "us-west-2")
+MQTT_PORT             = int(os.getenv("MQTT_PORT", "8883"))
 
 # ── TLS setup ──────────────────────────────────────────────────────────
 CA_CERT = CLIENT_CERT = PRIVATE_KEY = None
@@ -103,9 +106,9 @@ if TLS_SECRET_NAME:
         PRIVATE_KEY = creds.get("private_key")
 
 if not all([CA_CERT, CLIENT_CERT, PRIVATE_KEY]):
-    CA_CERT     = _materialise_pem("CA_CERT")
-    CLIENT_CERT = _materialise_pem("CLIENT_CERT")
-    PRIVATE_KEY = _materialise_pem("PRIVATE_KEY")
+    CA_CERT     = _materialise_pem("CA_CERT", "CA_CERT_PEM")
+    CLIENT_CERT = _materialise_pem("CLIENT_CERT", "CLIENT_CERT_PEM")
+    PRIVATE_KEY = _materialise_pem("PRIVATE_KEY", "PRIVATE_KEY_PEM")
 
 if not all([CA_CERT, CLIENT_CERT, PRIVATE_KEY]):
     print(
@@ -144,7 +147,7 @@ client.on_disconnect = _on_disconnect
 
 for attempt in range(1, 10):
     try:
-        client.connect(IOT_ENDPOINT, 8883, 60)
+        client.connect(IOT_ENDPOINT, MQTT_PORT, 60)
         break
     except Exception as e:
         print(f"MQTT connect failed (try {attempt}/5): {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- reinstate the mandatory TLS setup for the VEN MQTT client and add support for the `_PEM` suffixed environment variables when materialising certificates
- update the VEN unit tests to provide fake PEM data instead of disabling TLS
- document the accepted TLS environment variable names in the README

## Testing
- scripts/check_terraform.sh *(fails: terraform: command not found)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cd97d8ad508323a1ed3a868b1eba0a