### PR TITLE
Ensure IoT Core clients support VPC endpoint hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,12 @@ Re-running `terraform apply` will recreate the services when needed.
   environment variables `CA_CERT`, `CLIENT_CERT`, and `PRIVATE_KEY` (or the
   `_PEM`-suffixed variants) with the paths or PEM contents for your broker's
   certificate authority, client certificate and key to enable TLS.
-- By default the applications target the AWS IoT Core endpoint
-  `vpce-0d3cb8ea5764b8097-r1j8w787.data.iot.us-west-2.vpce.amazonaws.com`. Set
-  the `IOT_ENDPOINT` environment variable if you need to override this.
+- The applications default to the AWS IoT Core ATS data endpoint exported by
+  Terraform. When the services run behind the VPC interface endpoint,
+  Terraform also sets `IOT_CONNECT_HOST` to the private DNS name and
+  `IOT_TLS_SERVER_NAME` to the public IoT endpoint so TLS hostname checks still
+  succeed. Override these environment variables if you run the containers
+  outside this infrastructure.
 - The container applications are minimal examples. Customize `grid-event-gateway/vtn_server.py` and `volttron-ven/ven_agent.py` for your use case.
 
 ## Grid-Event Gateway
@@ -219,6 +222,9 @@ export IOT_ENDPOINT=a1mgxpe8mg484j-ats.iot.us-west-2.amazonaws.com
 export CA_CERT=/path/to/ca.pem
 export CLIENT_CERT=/path/to/client.crt
 export PRIVATE_KEY=/path/to/client.key
+# When using a private IoT VPC endpoint also set:
+# export IOT_CONNECT_HOST=your-private-endpoint.amazonaws.com
+# export IOT_TLS_SERVER_NAME=a1234567890-ats.iot.us-west-2.amazonaws.com
 ```
 
 Use `--port 8883` when connecting with TLS (otherwise the default `1883` is

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -81,7 +81,9 @@ module "ecs_service_grid_event_gateway" {
   mqtt_topic_events    = "oadr/event/ven1"
   mqtt_topic_responses = "oadr/response/ven1"
   mqtt_topic_metering  = "oadr/meter/ven1"
-  iot_endpoint         = "a1mgxpe8mg484j-ats.iot.us-west-2.amazonaws.com"
+  iot_endpoint         = module.iot_core.endpoint
+  iot_connect_host     = module.vpc.iot_data_endpoint_dns
+  iot_tls_server_name  = module.iot_core.endpoint
   container_port       = 8080
   vens_port            = 8081
   target_group_arn     = module.grid_event_gateway_alb.target_group_arn
@@ -115,7 +117,9 @@ module "ecs_service_volttron" {
   mqtt_topic_responses   = "oadr/response/ven1"
   mqtt_topic_metering    = "oadr/meter/ven1"
   mqtt_topic_status      = "ven/status/ven1"
-  iot_endpoint           = "a1mgxpe8mg484j-ats.iot.us-west-2.amazonaws.com"
+  iot_endpoint           = module.iot_core.endpoint
+  iot_connect_host       = module.vpc.iot_data_endpoint_dns
+  iot_tls_server_name    = module.iot_core.endpoint
   ca_cert_secret_arn     = "${aws_secretsmanager_secret.volttron_tls.arn}:ca_cert::"
   client_cert_secret_arn = "${aws_secretsmanager_secret.volttron_tls.arn}:client_cert::"
   private_key_secret_arn = "${aws_secretsmanager_secret.volttron_tls.arn}:private_key::"

--- a/grid-event-gateway/vtn_server.py
+++ b/grid-event-gateway/vtn_server.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 import json
 import os
+import ssl
 import sys
 import tempfile
 import threading
@@ -79,20 +80,75 @@ def handle_event_request(ven_id: str, payload: dict):
     mqttc.publish(MQTT_TOPIC_EVENTS, json.dumps(message))
     return [{"targets": {"ven_id": ven_id}, **payload}]
 
+
+def _dnsname_matches(pattern: str, hostname: str) -> bool:
+    pattern = pattern.lower()
+    hostname = hostname.lower()
+
+    if pattern.startswith("*."):
+        suffix = pattern[1:]
+        if not suffix or not hostname.endswith(suffix):
+            return False
+        prefix = hostname[: -len(suffix)]
+        return bool(prefix) and "." not in prefix
+
+    return pattern == hostname
+
+
+def _ensure_expected_server_hostname(mqtt_client: mqtt.Client, expected: str) -> None:
+    hostname = expected.strip()
+    if not hostname:
+        raise ssl.SSLError("Expected TLS server hostname not provided")
+
+    sock = mqtt_client.socket()
+    if sock is None:
+        raise ssl.SSLError("TLS socket not available for hostname verification")
+
+    cert = sock.getpeercert()
+    if not cert:
+        raise ssl.SSLError("TLS peer certificate missing")
+
+    dns_names = [value for key, value in cert.get("subjectAltName", ()) if key == "DNS"]
+    if not dns_names:
+        for subject in cert.get("subject", ()):  # fall back to CN when SAN absent
+            for key, value in subject:
+                if key.lower() == "commonname":
+                    dns_names.append(value)
+
+    if not dns_names:
+        raise ssl.CertificateError("TLS certificate does not present any DNS names")
+
+    for pattern in dns_names:
+        if _dnsname_matches(pattern, hostname):
+            return
+
+    raise ssl.CertificateError(
+        f"Hostname '{hostname}' does not match certificate names: {dns_names}"
+    )
+
 # ── ENV ------------------------------------------------------------------
 MQTT_TOPIC_METERING  = os.getenv("MQTT_TOPIC_METERING", "volttron/metering")
 MQTT_TOPIC_EVENTS    = os.getenv("MQTT_TOPIC_EVENTS",   "openadr/event")
 MQTT_TOPIC_RESPONSES = os.getenv("MQTT_TOPIC_RESPONSES","openadr/response")
 DEFAULT_IOT_ENDPOINT = "a1mgxpe8mg484j-ats.iot.us-west-2.amazonaws.com"
 IOT_ENDPOINT         = os.getenv("IOT_ENDPOINT",        DEFAULT_IOT_ENDPOINT)
+MQTT_CONNECT_HOST    = (
+    os.getenv("IOT_CONNECT_HOST")
+    or os.getenv("MQTT_CONNECT_HOST")
+    or IOT_ENDPOINT
+)
+TLS_SERVER_HOSTNAME  = (
+    os.getenv("IOT_TLS_SERVER_NAME")
+    or os.getenv("MQTT_TLS_SERVER_NAME")
+    or IOT_ENDPOINT
+)
 VENS_PORT            = int(os.getenv("VENS_PORT", 8081))
 
-MQTT_PORT = int(
-    os.getenv(
-        "MQTT_PORT",
-        "8883" if IOT_ENDPOINT != "localhost" else "1883",
-    )
-)
+default_mqtt_port = "8883"
+if IOT_ENDPOINT == "localhost" or MQTT_CONNECT_HOST == "localhost":
+    default_mqtt_port = "1883"
+
+MQTT_PORT = int(os.getenv("MQTT_PORT", default_mqtt_port))
 
 bundle_json = os.getenv("CERT_BUNDLE_JSON")
 CA_CERT_PEM = CLIENT_CERT_PEM = PRIVATE_KEY_PEM = None
@@ -109,6 +165,7 @@ else:
     print("⚠️ CERT_BUNDLE_JSON not provided; using insecure MQTT connection", file=sys.stderr)
 
 mqttc = mqtt.Client(protocol=mqtt.MQTTv5)
+manual_hostname_override = False
 
 if CA_CERT_PEM and CLIENT_CERT_PEM and PRIVATE_KEY_PEM:
     # ── materialise PEM strings to disk ---------------------------------
@@ -142,6 +199,20 @@ if CA_CERT_PEM and CLIENT_CERT_PEM and PRIVATE_KEY_PEM:
 
     mqttc.tls_set(ca_certs=ca_path, certfile=cert_path, keyfile=key_path)
 
+    manual_hostname_override = TLS_SERVER_HOSTNAME != MQTT_CONNECT_HOST
+    if manual_hostname_override:
+        print(
+            "🔐 TLS hostname override enabled: "
+            f"connecting to {MQTT_CONNECT_HOST} but verifying certificate for {TLS_SERVER_HOSTNAME}"
+        )
+    elif ".vpce." in MQTT_CONNECT_HOST:
+        print(
+            "⚠️ Connecting to an AWS IoT VPC endpoint without a TLS hostname override. "
+            "Set IOT_TLS_SERVER_NAME to your IoT data endpoint to enable certificate checks.",
+            file=sys.stderr,
+        )
+    mqttc.tls_insecure_set(manual_hostname_override)
+
 # ── MQTT client ----------------------------------------------------------
 mqtt_connected = False
 
@@ -153,9 +224,16 @@ mqttc.on_connect = _on_connect
 
 for attempt in range(1, 6):
     try:
-        mqttc.connect(IOT_ENDPOINT, MQTT_PORT, keepalive=60)
+        mqttc.connect(MQTT_CONNECT_HOST, MQTT_PORT, keepalive=60)
+        if manual_hostname_override:
+            _ensure_expected_server_hostname(mqttc, TLS_SERVER_HOSTNAME)
         break
     except Exception as e:
+        if mqttc.is_connected():
+            try:
+                mqttc.disconnect()
+            except Exception:
+                pass
         print(f"MQTT connect failed (try {attempt}/5): {e}", file=sys.stderr)
         time.sleep(min(2 ** attempt, 30))
 mqttc.loop_start()

--- a/modules/ecs-service-openadr/main.tf
+++ b/modules/ecs-service-openadr/main.tf
@@ -10,6 +10,8 @@ variable "mqtt_topic_events" {}
 variable "mqtt_topic_responses" {}
 variable "mqtt_topic_metering" {}
 variable "iot_endpoint" {}
+variable "iot_connect_host" { default = null }
+variable "iot_tls_server_name" { default = null }
 variable "target_group_arn" {}
 variable "assign_public_ip" { default = true }
 variable "cpu" { default = "256" }
@@ -44,13 +46,21 @@ resource "aws_ecs_task_definition" "this" {
           protocol      = "tcp"
         }
       ]
-      environment = [
-        { name = "MQTT_TOPIC_EVENTS", value = var.mqtt_topic_events },
-        { name = "MQTT_TOPIC_RESPONSES", value = var.mqtt_topic_responses },
-        { name = "MQTT_TOPIC_METERING", value = var.mqtt_topic_metering },
-        { name = "IOT_ENDPOINT", value = var.iot_endpoint },
-        { name = "VENS_PORT", value = tostring(var.vens_port) }
-      ]
+      environment = concat(
+        [
+          { name = "MQTT_TOPIC_EVENTS", value = var.mqtt_topic_events },
+          { name = "MQTT_TOPIC_RESPONSES", value = var.mqtt_topic_responses },
+          { name = "MQTT_TOPIC_METERING", value = var.mqtt_topic_metering },
+          { name = "IOT_ENDPOINT", value = var.iot_endpoint },
+          { name = "VENS_PORT", value = tostring(var.vens_port) }
+        ],
+        var.iot_connect_host == null ? [] : [
+          { name = "IOT_CONNECT_HOST", value = var.iot_connect_host }
+        ],
+        var.iot_tls_server_name == null ? [] : [
+          { name = "IOT_TLS_SERVER_NAME", value = var.iot_tls_server_name }
+        ]
+      )
       secrets = var.environment_secrets
       logConfiguration = {
         logDriver = "awslogs"

--- a/modules/ecs-service-volttron/main.tf
+++ b/modules/ecs-service-volttron/main.tf
@@ -10,6 +10,8 @@ variable "mqtt_topic_responses" {}
 variable "mqtt_topic_metering" {}
 variable "mqtt_topic_status" {}
 variable "iot_endpoint" {}
+variable "iot_connect_host" { default = null }
+variable "iot_tls_server_name" { default = null }
 variable "container_port" { default = 22916 }
 variable "target_group_arn" { default = null }
 variable "assign_public_ip" { default = true }
@@ -46,13 +48,21 @@ resource "aws_ecs_task_definition" "this" {
           protocol      = "tcp"
         }
       ]
-      environment = [
-        { name = "MQTT_TOPIC_EVENTS", value = var.mqtt_topic_events },
-        { name = "MQTT_TOPIC_RESPONSES", value = var.mqtt_topic_responses },
-        { name = "MQTT_TOPIC_METERING", value = var.mqtt_topic_metering },
-        { name = "MQTT_TOPIC_STATUS", value = var.mqtt_topic_status },
-        { name = "IOT_ENDPOINT", value = var.iot_endpoint }
-      ]
+      environment = concat(
+        [
+          { name = "MQTT_TOPIC_EVENTS", value = var.mqtt_topic_events },
+          { name = "MQTT_TOPIC_RESPONSES", value = var.mqtt_topic_responses },
+          { name = "MQTT_TOPIC_METERING", value = var.mqtt_topic_metering },
+          { name = "MQTT_TOPIC_STATUS", value = var.mqtt_topic_status },
+          { name = "IOT_ENDPOINT", value = var.iot_endpoint }
+        ],
+        var.iot_connect_host == null ? [] : [
+          { name = "IOT_CONNECT_HOST", value = var.iot_connect_host }
+        ],
+        var.iot_tls_server_name == null ? [] : [
+          { name = "IOT_TLS_SERVER_NAME", value = var.iot_tls_server_name }
+        ]
+      )
       secrets = [
         {
           name      = "CA_CERT_PEM"


### PR DESCRIPTION
## Summary
- add optional IoT connect host and TLS server name variables to the ECS service modules and wire them up in the dev environment
- update the VTN Python service to support separate connect and TLS hostnames and document the new environment variables
- extend the VTN unit tests to cover the TLS hostname override behaviour

## Testing
- scripts/check_terraform.sh *(fails: terraform: command not found)*
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d24032f38483238a4ad36c5f88d17a